### PR TITLE
support falcon-alliance, add packaging package

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,9 +2,10 @@ pandas==2.0.1
 plotly==5.14.1
 requests==2.30.0
 streamlit==1.28.0
-scipy==1.10.1
+scipy==1.9.3
+packaging==22.0 # need packaging for tbapy https://github.com/pypa/setuptools/issues/4501
 tbapy==1.3.2
-python-dotenv==1.0.1
+python-dotenv==0.21.1
 vaderSentiment==3.3.2
 st-annotated-text==4.0.1
 notion-client==2.2.1


### PR DESCRIPTION
can't install `tbapy` package w/o `packaging` package for some reason so this fixes error

after installing packaging on my system the first time, i could install `tbapy` 👍😁🥳 (😡👎☹️)

[source](https://github.com/pypa/setuptools/issues/4501)